### PR TITLE
Fix running performance benchmarks.

### DIFF
--- a/lib/result_handlers/performance_result_handler.rb
+++ b/lib/result_handlers/performance_result_handler.rb
@@ -17,6 +17,12 @@ module ResultHandlers
       build_implementation_result(impl_results, metrics, rubocop_offenses, scores)
     end
 
+    def calculate_best_results_by_implementation(results)
+      results.group_by { |r| r['implementation'] }
+             .filter_map { |_, impl_results| select_best_result(impl_results) }
+             .sort_by { |r| r['metrics']['execution_time'] || Float::INFINITY }
+    end
+
     private
 
     def extract_time_metrics(impl_results, metrics)
@@ -57,12 +63,6 @@ module ResultHandlers
           'quality_score' => scores[:quality_score].round(2)
         }
       }
-    end
-
-    def calculate_best_results_by_implementation(results)
-      results.group_by { |r| r['implementation'] }
-             .filter_map { |_, impl_results| select_best_result(impl_results) }
-             .sort_by { |r| r['metrics']['execution_time'] || Float::INFINITY }
     end
 
     def select_best_result(impl_results)


### PR DESCRIPTION
I was getting this error:

```
Mon Oct 06 06:36:20 matt@dev ~/src/llm-benchmarks main $ ./main.rb

Select operation: Run benchmarks

Select benchmark type for new implementations: Program fixer benchmarks (fix broken code)

Select benchmark: Run single model across all benchmarks
Choose an implementation to run across all benchmarks: gemini_2_5_flash_preview_05_20_openrouter_06_2025

Running Lru Cache...

Running benchmarks in random order...

Running benchmark with implementation: gemini_2_5_flash_preview_05_20_openrouter_06_2025
Running 5 iterations (performance type)...
Iteration 1/5: Starting heavy workload simulation with 5000000 operations...
Execution time: 1.769 seconds
Iteration 2/5: Starting heavy workload simulation with 5000000 operations...
Execution time: 1.8577 seconds
Iteration 3/5: Starting heavy workload simulation with 5000000 operations...
Execution time: 1.7614 seconds
Iteration 4/5: Starting heavy workload simulation with 5000000 operations...
Execution time: 1.7853 seconds
Iteration 5/5: Starting heavy workload simulation with 5000000 operations...
Execution time: 1.852 seconds
/home/matt/src/llm-benchmarks/lib/services/results_service.rb:46:in 'ResultsService#add_result': private method 'calculate_best_results_by_implementation' called for an instance of ResultHandlers::PerformanceResultHandler (NoMethodError)

    best_results = @result_handler.calculate_best_results_by_implementation(data['results'])
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Did you mean?  calculate_implementation_metrics
        from /home/matt/src/llm-benchmarks/lib/services/benchmark_runner_service.rb:135:in 'BenchmarkRunnerService#save_and_display_results'
        from /home/matt/src/llm-benchmarks/lib/services/benchmark_runner_service.rb:64:in 'BenchmarkRunnerService#run_implementation_iterations'
        from /home/matt/src/llm-benchmarks/lib/services/benchmark_runner_service.rb:38:in 'block in BenchmarkRunnerService#run'
        from /home/matt/src/llm-benchmarks/lib/services/benchmark_runner_service.rb:37:in 'Array#each'
        from /home/matt/src/llm-benchmarks/lib/services/benchmark_runner_service.rb:37:in 'BenchmarkRunnerService#run'
        from /home/matt/src/llm-benchmarks/lib/services/single_model_benchmark_service.rb:52:in 'SingleModelBenchmarkService#run_benchmark_for_implementation'
        from /home/matt/src/llm-benchmarks/lib/services/single_model_benchmark_service.rb:14:in 'block in SingleModelBenchmarkService#run'
        from /home/matt/src/llm-benchmarks/lib/services/single_model_benchmark_service.rb:13:in 'Array#each'
        from /home/matt/src/llm-benchmarks/lib/services/single_model_benchmark_service.rb:13:in 'SingleModelBenchmarkService#run'
        from ./main.rb:72:in 'Main#run_benchmarks'
        from ./main.rb:40:in 'Main#run'
        from ./main.rb:123:in '<main>'
```